### PR TITLE
Raise an issue only if we have less slaves than expected.

### DIFF
--- a/tools/bin/redis-replmon
+++ b/tools/bin/redis-replmon
@@ -84,7 +84,7 @@ class RedisReplicationMonitor
       end
     end
 
-    return slave_count if @slave == slave_count
+    return slave_count if @slaves == slave_count
 
     message = "Incorrect number of slaves: expected #{@slaves}, got #{slave_count}"
     failure message if @slaves > slave_count


### PR DESCRIPTION
I'm not 100% sure if this is good or not: keeping an eye on the number of slaves is good, but sometimes I'd like to be able to add new slaves without triggering any alarm.

R: @kvs, @coosh, @pallan.
