### PR TITLE
Scrub redis argument to prevent encoding issues

### DIFF
--- a/tools/bin/redis-slowlog
+++ b/tools/bin/redis-slowlog
@@ -15,7 +15,7 @@ class SlowLogger < RedisTool
       self.command      = command.join(' ')
       self.command_raw  = command
 
-      if command.last =~ /\A\.\.\. \((\d+) more arguments\)\z/
+      if command.last.scrub =~ /\A\.\.\. \((\d+) more arguments\)\z/
         self.arguments = command.count + $1.to_i - 2 # minus command (first) and "more arguments" (last)
       else
         self.arguments = command.count - 1 # minus command (first)


### PR DESCRIPTION
Recently I noticed this in the slow log:

```
2014-11-18_18:00:54.51307 event="exception" class="ArgumentError" message="invalid byte sequence in US-ASCII" backtrace="[\"/usr/local/bin/redis-slowlog:18:in `initialize'\" ...
```

Since we only care to match against pure ASCII characters `scrub` is good enough. But it mean a Ruby 2.1 dependency though.
