### PR TITLE
Don't rely on statically generated list of Redis slave nodes

### DIFF
--- a/tools/bin/redis-replmon
+++ b/tools/bin/redis-replmon
@@ -33,7 +33,6 @@ class RedisReplicationMonitor
     @name   = inst_name
     @vip    = instance["vip"]    or failure "No VIP configured"
     @port   = instance["port"]   or failure "No port configured"
-    @nodes  = instance["nodes"]  or failure "No nodes configured"
     @slaves = instance["slaves"] or failure "No slave count configured"
 
     @statsd = Statsd.new
@@ -70,18 +69,12 @@ class RedisReplicationMonitor
       slave = Hash[value.split(',').map { |field| field.split('=', 2) }]
       slave_addr = "#{slave['ip']}:#{slave['port']}"
 
-      known_slave = @nodes.include?(slave['ip']) && slave['port'].to_i == @port
-
-      opts = {:tags => ["slave:#{slave_addr}", "known:#{known_slave}"]}
+      opts = {:tags => ["slave:#{slave_addr}"]}
       @statsd.gauge('redis.replmon.slave.lag', slave['lag'], opts)
       @statsd.gauge('redis.replmon.slave.offset', slave['offset'].to_i, opts)
       @statsd.gauge('redis.replmon.slave.offset.delta', master_offset - slave['offset'].to_i, opts)
 
-      if known_slave
-        slave_count += 1 if slave['state'] == 'online'
-      else
-        notice "Unknown slave: #{slave_addr}"
-      end
+      slave_count += 1 if slave['state'] == 'online'
     end
 
     return slave_count if @slaves == slave_count


### PR DESCRIPTION
If I have a Redis master, and I know how many slaves I want it to have, and I know it has that many, why can't I just be happy?

This PR removes the requirement to hardcode the list of expected slave nodes when performing a Redis `replmon` check. This can simplify quite a bit of automation if you're using `replmon` from configuration management tools.
